### PR TITLE
Fix SQLite compatibility in reminder queries

### DIFF
--- a/app/Http/Controllers/Api/ReminderApiController.php
+++ b/app/Http/Controllers/Api/ReminderApiController.php
@@ -138,8 +138,9 @@ class ReminderApiController extends Controller
      */
     public function expiringSoon()
     {
+        // Use the model scope to remain compatible with both MySQL and SQLite
         $reminders = Auth::user()->reminders()
-            ->whereRaw('DATEDIFF(expiry_date, CURDATE()) <= alert_days_before')
+            ->expiringSoon()
             ->orderBy('expiry_date', 'asc')
             ->get();
             


### PR DESCRIPTION
## Summary
- use Reminder model scope to fetch expiring soon reminders
- ensure dashboard reminder queries work on SQLite

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8b41b60c833284e245509d9674dd