### PR TITLE
Standardize 'license' wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HandyPing
 
-Never forget another licence renewal - Simple SMS + email reminder tool for sole traders and mobile tradies.
+Never forget another license renewal - Simple SMS + email reminder tool for sole traders and mobile tradies.
 
 ## Features
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -25,7 +25,7 @@ class DatabaseSeeder extends Seeder
         // Create demo reminders
         $reminders = [
             [
-                'name' => 'White Card Licence',
+                'name' => 'White Card License',
                 'expiry_date' => Carbon::now()->addDays(3),
                 'alert_days_before' => 7,
                 'notification_method' => 'sms',

--- a/resources/js/pages/Landing.vue
+++ b/resources/js/pages/Landing.vue
@@ -21,7 +21,7 @@
     <section class="pt-20 pb-16 px-4">
       <div class="max-w-7xl mx-auto text-center">
         <h1 class="text-5xl md:text-6xl font-bold text-gray-900 mb-6">
-          Never forget another<br>licence renewal
+          Never forget another<br>license renewal
         </h1>
         <p class="text-xl md:text-2xl text-gray-600 mb-10 max-w-3xl mx-auto">
           Simple SMS & email reminders for your trade licenses, insurance, and certifications. 

--- a/resources/js/pages/Login.vue
+++ b/resources/js/pages/Login.vue
@@ -4,7 +4,7 @@
       <!-- Logo/Title -->
       <div class="text-center">
         <h1 class="text-4xl font-bold text-gray-900 mb-2">HandyPing</h1>
-        <p class="text-gray-600">Never forget another licence renewal</p>
+        <p class="text-gray-600">Never forget another license renewal</p>
       </div>
 
       <!-- Phone Number Form -->

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
 
-    <title>{{ config('app.name', 'HandyPing') }} - Never forget another licence renewal</title>
+    <title>{{ config('app.name', 'HandyPing') }} - Never forget another license renewal</title>
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.bunny.net">


### PR DESCRIPTION
## Summary
- switch to American spelling in views and pages
- standardize language in README and database seeder

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8d5003748332ac4e5045d49ad23f