### PR TITLE
Fix date calculations for reminders

### DIFF
--- a/app/Http/Controllers/Api/ReminderApiController.php
+++ b/app/Http/Controllers/Api/ReminderApiController.php
@@ -24,7 +24,7 @@ class ReminderApiController extends Controller
         
         if ($request->has('status')) {
             if ($request->status === 'expiring_soon') {
-                $query->whereDate('expiry_date', '<=', Carbon::now()->addDays(7));
+                $query->expiringSoon();
             }
         }
         
@@ -139,7 +139,7 @@ class ReminderApiController extends Controller
     public function expiringSoon()
     {
         $reminders = Auth::user()->reminders()
-            ->whereRaw('DATEDIFF(expiry_date, CURDATE()) <= alert_days_before')
+            ->expiringSoon()
             ->orderBy('expiry_date', 'asc')
             ->get();
             

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -17,7 +17,7 @@ class DashboardController extends Controller
         
         // Get reminders expiring soon
         $expiringSoon = $user->reminders()
-            ->whereRaw('DATEDIFF(expiry_date, CURDATE()) <= alert_days_before')
+            ->expiringSoon()
             ->orderBy('expiry_date', 'asc')
             ->take(5)
             ->get()
@@ -29,7 +29,7 @@ class DashboardController extends Controller
         
         // Get upcoming reminders
         $upcomingReminders = $user->reminders()
-            ->whereRaw('DATEDIFF(expiry_date, CURDATE()) > alert_days_before')
+            ->upcoming()
             ->orderBy('expiry_date', 'asc')
             ->take(10)
             ->get()

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    use CreatesApplication;
+}

--- a/tests/Unit/ReminderScopeTest.php
+++ b/tests/Unit/ReminderScopeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use App\Models\Reminder;
+use Carbon\Carbon;
+
+class ReminderScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_returns_expiring_soon_reminders()
+    {
+        $user = User::create([
+            'name' => 'Test',
+            'email' => 'test@example.com',
+            'phone' => '0411111111',
+            'password' => 'secret',
+        ]);
+
+        $expiring = $user->reminders()->create([
+            'name' => 'Expiring',
+            'expiry_date' => Carbon::now()->addDay(),
+            'alert_days_before' => 7,
+            'notification_method' => 'sms',
+        ]);
+
+        $user->reminders()->create([
+            'name' => 'Later',
+            'expiry_date' => Carbon::now()->addDays(20),
+            'alert_days_before' => 7,
+            'notification_method' => 'sms',
+        ]);
+
+        $results = Reminder::query()->expiringSoon()->get();
+
+        $this->assertCount(1, $results);
+        $this->assertTrue($results->first()->is($expiring));
+    }
+
+    /** @test */
+    public function it_returns_upcoming_reminders()
+    {
+        $user = User::create([
+            'name' => 'Test',
+            'email' => 'test2@example.com',
+            'phone' => '0422222222',
+            'password' => 'secret',
+        ]);
+
+        $upcoming = $user->reminders()->create([
+            'name' => 'Upcoming',
+            'expiry_date' => Carbon::now()->addDays(20),
+            'alert_days_before' => 7,
+            'notification_method' => 'sms',
+        ]);
+
+        $user->reminders()->create([
+            'name' => 'Soon',
+            'expiry_date' => Carbon::now()->addDay(),
+            'alert_days_before' => 7,
+            'notification_method' => 'sms',
+        ]);
+
+        $results = Reminder::query()->upcoming()->get();
+
+        $this->assertCount(1, $results);
+        $this->assertTrue($results->first()->is($upcoming));
+    }
+}


### PR DESCRIPTION
## Summary
- unify date difference logic for reminders
- add upcoming scope to Reminder model
- update dashboard and reminder API to use scopes
- scaffold PHPUnit and add unit tests for scopes

## Testing
- `phpunit --configuration phpunit.xml tests/Unit/ReminderScopeTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8d6306548332859749c5b005c396