### PR TITLE
Add basic auth API feature tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertDeprecationsToExceptions="true">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./app</directory>
+        </include>
+    </coverage>
+
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="SANCTUM_STATEFUL_DOMAINS" value="localhost"/>
+    </php>
+</phpunit>

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    /**
+     * Creates the application.
+     *
+     * @return \Illuminate\Foundation\Application
+     */
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/Feature/AuthApiTest.php
+++ b/tests/Feature/AuthApiTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class AuthApiTest extends TestCase
+{
+    public function test_verify_phone_returns_success()
+    {
+        $response = $this->postJson('/api/verify-phone', [
+            'phone' => '0412345678',
+        ]);
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'success' => true,
+                 ]);
+    }
+
+    public function test_verify_code_creates_token()
+    {
+        Cache::put('phone_verification_0412345678', '123456', now()->addMinutes(10));
+
+        $response = $this->postJson('/api/verify-code', [
+            'phone' => '0412345678',
+            'code' => '123456',
+        ]);
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'success' => true,
+                 ])
+                 ->assertJsonStructure([
+                     'token',
+                     'user',
+                 ]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    use CreatesApplication;
+}


### PR DESCRIPTION
## Summary
- set up PHPUnit config
- provide Laravel test boilerplate
- add Auth API feature tests

## Testing
- `php artisan test` *(fails: `bash: php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f8d7261488332b1245a7c3c6b9d80